### PR TITLE
[MachO] Fix unaligned load in extractSections

### DIFF
--- a/llvm/lib/ObjCopy/MachO/MachOReader.cpp
+++ b/llvm/lib/ObjCopy/MachO/MachOReader.cpp
@@ -67,7 +67,7 @@ Expected<std::vector<std::unique_ptr<Section>>> static extractSections(
                                                         LoadCmd.C.cmdsize);
        Curr < End; ++Curr) {
     SectionType Sec;
-    memcpy((void *)&Sec, Curr, sizeof(SectionType));
+    memcpy((void *)&Sec, reinterpret_cast<const char*>(Curr), sizeof(SectionType));
 
     if (MachOObj.isLittleEndian() != sys::IsLittleEndianHost)
       MachO::swapStruct(Sec);


### PR DESCRIPTION
A recent change to ubsan
(https://github.com/llvm/llvm-project/commit/792674400f6f04a074a3827349ed0e2ac10067f6)
exposed an unaligned load in MachOReader (see
https://lab.llvm.org/buildbot/#/builders/85/builds/19482 for an example).

This patch fixes it by dropping the alignment.
